### PR TITLE
Changed line length to 80

### DIFF
--- a/tools/autoformat.py
+++ b/tools/autoformat.py
@@ -28,6 +28,9 @@ def _run_cmd(args):
             "--check" if args.check else None,
             "--quiet" if args.quiet else None,
             "--verbose" if args.verbose else None,
+            # default line length should be 80 chars
+            "--line-length",
+            "80",
         ]
         + args.files
         + (["--exclude"] + args.exclude if args.exclude else [None])
@@ -75,7 +78,9 @@ def main():
         default=["."],
         help="list of files to check",
     )
-    parser.add_argument("-e", "--exclude", nargs="*", help="list of files to skip")
+    parser.add_argument(
+        "-e", "--exclude", nargs="*", help="list of files to skip"
+    )
     parser.add_argument(
         "-r",
         "--reformat",

--- a/tools/autoformat.py
+++ b/tools/autoformat.py
@@ -28,7 +28,9 @@ def _run_cmd(args):
             "--check" if args.check else None,
             "--quiet" if args.quiet else None,
             "--verbose" if args.verbose else None,
-            # default line length should be 80 chars
+            # Line length is hardcoded to be 80 chars as changing this value
+            # could reformat the whole workspace. There is no need for a user to
+            # change this value.
             "--line-length",
             "80",
         ]


### PR DESCRIPTION
Now the black CLI that is run from within autoformat is hardcoded to add a `--line-length 80` to the end of the options