### PR TITLE
Search for "FAIL_COMMIT" literal (in-repo check)

### DIFF
--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -74,12 +74,13 @@ def _run_check(_):
 
     failed = {}
     for file in include_files:
-        print(include_files, file)
         if os.stat(file).st_size == 0:
             continue
         with open(file, encoding="utf-8") as f_read:
             for exp_line in _generate_expected(file):
                 line = f_read.readline().strip("\n")
+                if line.startswith("#!"):
+                    f_read.readline().strip("\n")
                 if not re.match(exp_line, line):
                     failed[file] = line
                     break

--- a/tools/fc_check
+++ b/tools/fc_check
@@ -1,7 +1,33 @@
-```
-├───artifacts              : folder to store all output artifacts of main code/scripts
-│       hukamnama.json     : file to store data about hukamnamas
-├───src                    : main code goes in this directory
-│       main.py            : main code goes in this file
-├───test                   : test code, and other related files/code go in this directory
-│   └───src                : main test code goes in this dir
+#!/bin/sh
+# ------------------------------------------------------------------------------
+# fc_check - Check for string literal to block github merge into main.
+#
+# September 2022, Gurkiran Singh
+#
+# Copyright (c) 2022
+# All rights reserved.
+# ------------------------------------------------------------------------------
+
+FC_STRING1="FAIL_"
+FC_STRING2="COMMIT"
+FC_STRING="$FC_STRING1$FC_STRING2"
+
+EXCLUDE_DIR=".git/"
+
+CMD="grep -rni $FC_STRING --exclude-dir=$EXCLUDE_DIR"
+OUTPUT=$(eval "$CMD")
+RC=$?
+
+if [ $RC -eq 0 ] # matching files found
+then
+    echo "$FC_STRING strings found. Please remove:"
+    echo $OUTPUT
+elif [ $RC -eq 1 ] # matching files not found
+then
+    echo "No files found with '$FC_STRING'."
+else
+    echo "Error running bash command."
+    echo "  Command ran: $CMD"
+    echo "  Output: $OUTPUT"
+    echo "  Return code $RC"
+fi

--- a/tools/fc_check
+++ b/tools/fc_check
@@ -19,10 +19,9 @@ RC_ERROR=2
 EXCLUDE_DIR=".git/"
 
 CMD="grep -rni $FC_STRING --exclude-dir=$EXCLUDE_DIR"
-OUTPUT=eval{$CMD}
-RC=$?
 
-echo $OUTPUT
+OUTPUT="$($CMD)"
+RC="$?"
 
 if [ $RC -eq 0 ] # matching files found
 then

--- a/tools/fc_check
+++ b/tools/fc_check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------------
 # fc_check - Check for string literal to block github merge into main.
 #
@@ -12,22 +12,31 @@ FC_STRING1="FAIL_"
 FC_STRING2="COMMIT"
 FC_STRING="$FC_STRING1$FC_STRING2"
 
+RC_PASS=0
+RC_FAIL=1
+RC_ERROR=2
+
 EXCLUDE_DIR=".git/"
 
 CMD="grep -rni $FC_STRING --exclude-dir=$EXCLUDE_DIR"
-OUTPUT=$(eval "$CMD")
+OUTPUT=eval{$CMD}
 RC=$?
+
+echo $OUTPUT
 
 if [ $RC -eq 0 ] # matching files found
 then
     echo "$FC_STRING strings found. Please remove:"
     echo $OUTPUT
+    exit $RC_FAIL
 elif [ $RC -eq 1 ] # matching files not found
 then
     echo "No files found with '$FC_STRING'."
+    exit $RC_PASS
 else
     echo "Error running bash command."
     echo "  Command ran: $CMD"
     echo "  Output: $OUTPUT"
     echo "  Return code $RC"
+    exit $RC_ERROR
 fi


### PR DESCRIPTION
Checks for `FAIL_COMMIT` string literals in the repo (not case-sensitive). If a file is found with this, raise an error