### PR TITLE
Improve Regex matching in copyright checks

### DIFF
--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -18,6 +18,8 @@ file in the repo. It should be formatted as follows:"""
 # All rights reserved.
 # ------------------------------------------------------------------------------
 
+__all__s = []
+
 from dataclasses import dataclass
 from datetime import date
 
@@ -46,7 +48,7 @@ class _LineMatchInfo:
 
 def _generate_expected(file_path):
     """
-    Generator tha outputs each line of a correctly formatted copyright notice.
+    Generator that outputs each line of a correctly formatted copyright notice.
 
     :param file_path:
         Path to the file to generate an copyright notice for.
@@ -148,7 +150,8 @@ def main():
         "--show-regex",
         action="store_true",
         default=False,
-        help="Provide regex rule that malformed line should match.",
+        help="If the check fails on a given file, provide the regex rule that "
+        "the malformed line should match.",
     )
 
     args = parser.parse_args()

--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -18,8 +18,7 @@ file in the repo. It should be formatted as follows:"""
 # All rights reserved.
 # ------------------------------------------------------------------------------
 
-__all__ = []
-
+from dataclasses import dataclass
 from datetime import date
 
 import argparse
@@ -38,6 +37,16 @@ class _CopyrightCheckReturnCodes(cmn.ReturnCodes):
     CHANGES_REQUIRED = 1
 
 
+@dataclass(frozen=True)
+class _LineMatchInfo:
+    line_number: int
+    act_line: str
+    exp_line: str
+
+
+
+
+
 def _generate_expected(file_path):
     """
     Generator tha outputs each line of a correctly formatted copyright notice.
@@ -49,41 +58,57 @@ def _generate_expected(file_path):
         Regex for a copyright notice, output line-by-line.
     """
     file_name = file_path.split("/")[-1]
+    notice_start_end = r"^# ^[-]{78}$"
+    blank_line = r"^#$"
+
     exp = [
-        "# -----------------------------------------------------------------------------",
-        f"# {file_name} - [^.*]",
-        "#",
-        "# (January|February|March|April|May|June|July|August|September|October|November|December)"
-        r" 20[0-9]{2}, [A-Za-z -]",
-        "#",
-        rf"# Copyright \(c\) (20[0-9]{{2}} - ){{0,1}}{date.today().year}",
-        "# All rights reserved.",
-        "# -----------------------------------------------------------------------------",
+        notice_start_end,
+        rf"^# {file_name} - [^.*]$",
+        blank_line,
+        r"^# (January|February|March|April|May|June|July|August|September|October|November|December)$"
+        r"^# 20[0-9]{2}, [A-Za-z -]$",
+        blank_line,
+        rf"^# Copyright \(c\) (20[0-9]{{2}} - ){{0,1}}{date.today().year}$",
+        r"^# All rights reserved.$",
+        notice_start_end,
     ]
 
     for line in exp:
         yield line
 
 
-def _run_check(_):
+def _run_check(args):
     """
     Runs copyright checks on input parameters.
 
     :param args:
         Namespace object with args to run check on.
     """
-    include_files = cmn.get_all_code_files()
+    def read_line():
+        nonlocal line_number
+        line_number += 1
+        return f_read.readline().strip("\n")
 
     failed = {}
+    line_number = 0
+
+    include_files = cmn.get_all_code_files()
+
     for file in include_files:
-        print(include_files, file)
+        line_number=0
         if os.stat(file).st_size == 0:
             continue
         with open(file, encoding="utf-8") as f_read:
             for exp_line in _generate_expected(file):
-                line = f_read.readline().strip("\n")
+                line = read_line()
+                if line.startswith("#!"):
+                    line = read_line()
                 if not re.match(exp_line, line):
-                    failed[file] = line
+                    failed[file] = _LineMatchInfo(
+                        line_number,
+                        act_line=line,
+                        exp_line=exp_line,
+                    )
                     break
 
     if failed:  # pylint: disable=no-else-return
@@ -91,8 +116,15 @@ def _run_check(_):
             "Copyright notice checks failed! "
             "The following files need to be fixed:"
         )
-        for file, line in failed.items():
-            print(f"   - {file}: {line}")
+
+        for file, line_info in failed.items():
+            if args.verbose:
+                print(f"   - {file}:{line_info.line_number}:")
+                print(f"        {line_info.act_line} does not match")
+                print(f"        {line_info.exp_line}")
+            else:
+                print(f"   - {file}:{line_info.line_number}:    {line_info.act_line}")
+
         return _CopyrightCheckReturnCodes.CHANGES_REQUIRED
     else:
         print(
@@ -107,6 +139,14 @@ def main():
     parser = argparse.ArgumentParser(
         description="Check if all files have correctly formatted copyright checks. "
         "Optionally add/modify the notice on any files that fail the check."
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Provide regex rule that malformed line should match.",
     )
 
     args = parser.parse_args()

--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -44,9 +44,6 @@ class _LineMatchInfo:
     exp_line: str
 
 
-
-
-
 def _generate_expected(file_path):
     """
     Generator tha outputs each line of a correctly formatted copyright notice.
@@ -58,15 +55,15 @@ def _generate_expected(file_path):
         Regex for a copyright notice, output line-by-line.
     """
     file_name = file_path.split("/")[-1]
-    notice_start_end = r"^# ^[-]{78}$"
+    notice_start_end = r"^# [-]{78}$"
     blank_line = r"^#$"
 
     exp = [
         notice_start_end,
-        rf"^# {file_name} - [^.*]$",
+        rf"^# {file_name} - .+$",
         blank_line,
-        r"^# (January|February|March|April|May|June|July|August|September|October|November|December)$"
-        r"^# 20[0-9]{2}, [A-Za-z -]$",
+        r"^# (January|February|March|April|May|June|July|August|September|October|November|December)"\
+        r" 20[0-9]{2}, [A-Za-z -]+$",
         blank_line,
         rf"^# Copyright \(c\) (20[0-9]{{2}} - ){{0,1}}{date.today().year}$",
         r"^# All rights reserved.$",
@@ -120,10 +117,10 @@ def _run_check(args):
         for file, line_info in failed.items():
             if args.show_regex:
                 print(f"   - {file}:{line_info.line_number}:")
-                print(f"        {line_info.act_line} does not match")
-                print(f"        {line_info.exp_line}")
+                print(f"        `{line_info.act_line}` does not match")
+                print(f"        `{line_info.exp_line}`")
             else:
-                print(f"   - {file}:{line_info.line_number}:    {line_info.act_line}")
+                print(f"   - {file}:{line_info.line_number}:    `{line_info.act_line}`")
 
         return _CopyrightCheckReturnCodes.CHANGES_REQUIRED
     else:

--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -58,17 +58,19 @@ def _generate_expected(file_path):
     notice_start_end = r"^# [-]{78}$"
     blank_line = r"^#$"
 
+    # pylint: disable=line-too-long
     exp = [
         notice_start_end,
         rf"^# {file_name} - .+$",
         blank_line,
-        r"^# (January|February|March|April|May|June|July|August|September|October|November|December)"\
+        r"^# (January|February|March|April|May|June|July|August|September|October|November|December)"
         r" 20[0-9]{2}, [A-Za-z -]+$",
         blank_line,
         rf"^# Copyright \(c\) (20[0-9]{{2}} - ){{0,1}}{date.today().year}$",
         r"^# All rights reserved.$",
         notice_start_end,
     ]
+    # pylint: enable=line-too-long
 
     for line in exp:
         yield line
@@ -81,6 +83,7 @@ def _run_check(args):
     :param args:
         Namespace object with args to run check on.
     """
+
     def read_line():
         nonlocal line_number
         line_number += 1
@@ -92,7 +95,7 @@ def _run_check(args):
     include_files = cmn.get_all_code_files()
 
     for file in include_files:
-        line_number=0
+        line_number = 0
         if os.stat(file).st_size == 0:
             continue
         with open(file, encoding="utf-8") as f_read:
@@ -120,7 +123,9 @@ def _run_check(args):
                 print(f"        `{line_info.act_line}` does not match")
                 print(f"        `{line_info.exp_line}`")
             else:
-                print(f"   - {file}:{line_info.line_number}:    `{line_info.act_line}`")
+                print(
+                    f"   - {file}:{line_info.line_number}:    `{line_info.act_line}`"
+                )
 
         return _CopyrightCheckReturnCodes.CHANGES_REQUIRED
     else:

--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -118,7 +118,7 @@ def _run_check(args):
         )
 
         for file, line_info in failed.items():
-            if args.verbose:
+            if args.show_regex:
                 print(f"   - {file}:{line_info.line_number}:")
                 print(f"        {line_info.act_line} does not match")
                 print(f"        {line_info.exp_line}")
@@ -142,8 +142,8 @@ def main():
     )
 
     parser.add_argument(
-        "-v",
-        "--verbose",
+        "-r",
+        "--show-regex",
         action="store_true",
         default=False,
         help="Provide regex rule that malformed line should match.",

--- a/tools/copyright.py
+++ b/tools/copyright.py
@@ -18,7 +18,7 @@ file in the repo. It should be formatted as follows:"""
 # All rights reserved.
 # ------------------------------------------------------------------------------
 
-__all__s = []
+__all__ = []
 
 from dataclasses import dataclass
 from datetime import date


### PR DESCRIPTION
Regex rules were not nearly strict enough and passed too many strings through. They now enforce string start and end, so that the rule `r"one"` does not match the literal `"Honest"`.

This uncovered further issues such as looking for a single character match e.g. (`[A-Za-z]`) instead of multiple (`[A-Za-z]+`).