### PR TITLE
Add runner for all in-repo tests

### DIFF
--- a/tools/fc_check
+++ b/tools/fc_check
@@ -23,19 +23,19 @@ CMD="grep -rni $FC_STRING --exclude-dir=$EXCLUDE_DIR"
 OUTPUT="$($CMD)"
 RC="$?"
 
-if [ $RC -eq 0 ] # matching files found
-then
+if [ $RC -eq 0 ]; then # matching files found
     echo "$FC_STRING strings found. Please remove:"
     echo $OUTPUT
-    exit $RC_FAIL
-elif [ $RC -eq 1 ] # matching files not found
-then
+    RC=$RC_FAIL
+elif [ $RC -eq 1 ]; then # matching files not found
     echo "No files found with '$FC_STRING'."
-    exit $RC_PASS
+    RC=$RC_PASS
 else
     echo "Error running bash command."
     echo "  Command ran: $CMD"
     echo "  Output: $OUTPUT"
     echo "  Return code $RC"
-    exit $RC_ERROR
+    RC=$RC_ERROR
 fi
+
+exit $RC

--- a/tools/run_checks
+++ b/tools/run_checks
@@ -1,0 +1,54 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# run_checks - Run all checks in the tools directory.
+#
+# September 2022, Gurkiran Singh
+#
+# Copyright (c) 2022
+# All rights reserved.
+# ------------------------------------------------------------------------------
+
+TESTS=("Autoformat" "Copyright check" "Fail commit string check" "Lint")
+CMDS=("python tools/autoformat.py" "python tools/copyright.py" "tools/fc_check" "python tools/lint.py")
+
+
+echo "Running checks:"
+RC=0
+FAILED_TESTS=()
+
+for i in "${!TESTS[@]}"; do
+    TEST="${TESTS[i]}"
+    CMD="${CMDS[i]}"
+
+    echo -n " - $TEST: "
+
+    $CMD > /dev/null 2>&1
+    TEST_RC="$?"
+
+    if [ $TEST_RC -eq 0 ]; then # test passed
+        echo "PASSED"
+    else
+        echo "FAILED"
+        ((++RC))
+        FAILED_TESTS+=("$TEST ( $CMD )")
+    fi
+done
+
+echo "Tests complete."
+echo
+
+if [ $RC -eq 0 ]; then
+    echo "All tests passed! Please verify results manually where appropriate."
+else
+    # this if statement is just for singular vs plural grammar
+    if [ $RC -eq 1 ]; then
+        echo "The following test failed:"
+    else
+        echo "The following tests failed:"
+    fi
+    for TEST in "${FAILED_TESTS[@]}"; do
+        echo "- $TEST"
+    done
+fi
+
+exit $RC


### PR DESCRIPTION
All new in-repo tests must get added to this file (`tools/run_checks`). All the tests added to the file get run and whether they pass or fail is output to stdout. A list of failed tests is given after all tests have runned. The script's return code is equal to the number of tests that failed.