### PR TITLE
Make `branch_name` test pass on `main`

### DIFF
--- a/tools/branch_name.py
+++ b/tools/branch_name.py
@@ -27,9 +27,9 @@ class _BranchNameReturnCodes(cmn.ReturnCodes):
     """Possible exit codes from this branch name checker."""
 
     SUCCESS = 0
-    MAIN = 1
-    INVALID_BRANCH = 2
-    ERROR = 3
+    MAIN = 0
+    INVALID_BRANCH = 1
+    ERROR = 2
 
 
 def _check_branch_name_validity(branch_name: str) -> int:
@@ -50,7 +50,7 @@ def _check_branch_name_validity(branch_name: str) -> int:
     elif branch_name == "main":
         rc = _BranchNameReturnCodes.MAIN
         print(
-            "Oops! Still on `main`. Move your changes to a new branch by doing:\n"
+            "Still on `main`. Move your changes to a new branch by doing:\n"
             "    `git checkout -b <new-branch>"
         )
     else:


### PR DESCRIPTION
Without this fix, all commits will fail when run in the main github branch. The output when the branch is main is (mostly) unchanged but the return code is now `0` (no error)